### PR TITLE
Added no gRPC support

### DIFF
--- a/no.proto
+++ b/no.proto
@@ -1,0 +1,2 @@
+// TODO: Add no service definition
+


### PR DESCRIPTION
Added no support for a high performance, open-source universal RPC framework([gRPC](https://grpc.io/))