### PR TITLE
Use husky and lint-staged to prevent accidental code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{   
+    "plugins": ["nocode"],
+    "rules": {
+        "nocode/nocode": 2
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "nocode",
+    "private": true,
+    "version": "0.0.1",
+    "scripts": {
+        "precommit": "lint-staged",
+        "test": "eslint ."
+    },
+    "lint-staged": {
+        "*.js": [
+            "eslint --fix",
+            "git add"
+        ]
+    },
+    "devDependencies": {
+        "eslint": "^4.17.0",
+        "eslint-plugin-nocode": "^0.0.4",
+        "husky": "^0.14.3",
+        "lint-staged": "^6.1.0"
+    }
+}


### PR DESCRIPTION
This PR adds `husky` and `lint-staged` configuration as well as a `nocode` eslint rule, to prevent any JavaScript code from ever accidentally being added to the `nocode` repository.

To use this:

```
yarn
```

To install the dependencies.

Now create a file called test.js and write some code in it.

Try to commit the code! You should see an "Unexpected code" error! Also editors like VS Code will complain loudly about the eslint error.

Note: This PR does not itself add any code; this is all achieved entirely through configuration!

Note 2: Files with the .js extension that contain *no* code can still be committed.