### PR TITLE
Avoid committing any source by filtering it out from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.c
+*.h
+*.js
+*.py
+*.html
+*.htm
+*.java
+*.cs


### PR DESCRIPTION
In this pull request:
- added .gitignore filtering out most common programming languages source file extension.
- increases reliability of no code committing process
- only an initial commit, the .gitignore list must be completed