### PR TITLE
Add Sigstore integration to nocode

### DIFF
--- a/sigstore-integration-policy
+++ b/sigstore-integration-policy
@@ -1,0 +1,11 @@
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: nocode-nopolicy-nokey-noproblem
+spec:
+  images:
+  - glob: "**"
+  - key:
+        data: |
+          -----BEGIN PUBLIC KEY-----
+          -----END PUBLIC KEY-----


### PR DESCRIPTION
This policy will prevent nocode from running unless it's been signed by nokey