### PR TITLE
Remove Code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM scratch
+


### PR DESCRIPTION
The line, which is considered code by some standards, in `Dockerfile` allows for deployment somewhere, which is contrary to the statement in the `README.md` which states "Deploy Nowhere"